### PR TITLE
Add xUnit tests for / and /products endpoints (#2)

### DIFF
--- a/DevOpsDemo.Api/Program.cs
+++ b/DevOpsDemo.Api/Program.cs
@@ -43,3 +43,5 @@ app.MapGet("/products", async (HttpClient http) =>
 
 
 app.Run();
+// To make Program class accessible for integration tests
+public partial class Program { }

--- a/DevOpsDemo.Tests/DevOpsDemo.Tests.csproj
+++ b/DevOpsDemo.Tests/DevOpsDemo.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DevOpsDemo.Api\DevOpsDemo.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DevOpsDemo.Tests/UnitTest1.cs
+++ b/DevOpsDemo.Tests/UnitTest1.cs
@@ -1,0 +1,46 @@
+﻿using System.Net;
+using System.Text.Json;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace DevOpsDemo.Tests
+{
+    public class ApiTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly HttpClient _client;
+
+        public ApiTests(WebApplicationFactory<Program> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task RootEndpoint_ReturnsOk()
+        {
+            var response = await _client.GetAsync("/");
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+
+            Assert.True(json.TryGetProperty("name", out var name));
+            Assert.Equal("DevOps ASP.NET 9 Demo API", name.GetString());
+        }
+
+        [Fact]
+        public async Task ProductsEndpoint_ReturnsData()
+        {
+            var response = await _client.GetAsync("/products");
+
+            Assert.True(response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.Forbidden,
+                "Expected 200 OK or 403 Forbidden from CoinGecko");
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadFromJsonAsync<dynamic>();
+                Assert.NotNull(json);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds xUnit tests for minimal API endpoints:
- / returns API status
- /products returns external API data

Closes #2
